### PR TITLE
test: add lifecycle remote config fixtures

### DIFF
--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -47,8 +47,6 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
-    requires:
-      - name: backend-svc-required
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc
@@ -61,14 +59,3 @@ services:
           - master.pdb.create=true
           - master.pdb.minAvailable=50%
           - master.count=2
-  - name: backend-svc-required
-    helm:
-      repository: vigneshrajsb/backend-svc
-      branchName: main
-      chart:
-        name: redis
-        version: 20.3.0
-        repoUrl: https://charts.bitnami.com/bitnami
-        values:
-          - master.pdb.create=true
-          - master.pdb.minAvailable=50%

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -29,6 +29,8 @@ environment:
         ENV: lifecycle
 services:
   - name: backend-svc
+    requires:
+      - name: backend-svc-required
     helm:
       repository: vigneshrajsb/backend-svc
       branchName: main
@@ -47,6 +49,16 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
+  - name: backend-svc-required
+    helm:
+      repository: vigneshrajsb/backend-svc
+      branchName: main
+      chart:
+        name: redis
+        version: 20.3.0
+        repoUrl: https://charts.bitnami.com/bitnami
+        values:
+          - master.count=1
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -47,6 +47,8 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
+    requires:
+      - name: backend-svc-required
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc
@@ -59,3 +61,14 @@ services:
           - master.pdb.create=true
           - master.pdb.minAvailable=50%
           - master.count=2
+  - name: backend-svc-required
+    helm:
+      repository: vigneshrajsb/backend-svc
+      branchName: main
+      chart:
+        name: redis
+        version: 20.3.0
+        repoUrl: https://charts.bitnami.com/bitnami
+        values:
+          - master.pdb.create=true
+          - master.pdb.minAvailable=50%

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -30,7 +30,7 @@ environment:
 services:
   - name: backend-svc
     requires:
-      - name: backend-svc-required
+      - name: backend-svc-required-renamed
     helm:
       repository: vigneshrajsb/backend-svc
       branchName: main
@@ -49,7 +49,7 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
-  - name: backend-svc-required
+  - name: backend-svc-required-renamed
     helm:
       repository: vigneshrajsb/backend-svc
       branchName: main

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -29,8 +29,6 @@ environment:
         ENV: lifecycle
 services:
   - name: backend-svc
-    requires:
-      - name: backend-svc-required-renamed
     helm:
       repository: vigneshrajsb/backend-svc
       branchName: main
@@ -49,16 +47,6 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
-  - name: backend-svc-required-renamed
-    helm:
-      repository: vigneshrajsb/backend-svc
-      branchName: main
-      chart:
-        name: redis
-        version: 20.3.0
-        repoUrl: https://charts.bitnami.com/bitnami
-        values:
-          - master.count=1
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -6,6 +6,19 @@ environment:
   defaultServices:
     - name: 'backend-cache'
     - name: 'backend-svc'
+    - name: 'frontend'
+      repository: 'vigneshrajsb/lifecycle-examples'
+      branch: 'codex/lfc-remote-config-fixture'
+    - name: 'backend'
+      repository: 'vigneshrajsb/lifecycle-examples'
+      branch: 'codex/lfc-remote-config-fixture'
+    - name: 'remote-fixture-a'
+      repository: 'vigneshrajsb/lifecycle-examples'
+      branch: 'codex/lfc-remote-config-fixture'
+  optionalServices:
+    - name: 'cache'
+      repository: 'vigneshrajsb/lifecycle-examples'
+      branch: 'codex/lfc-remote-config-fixture'
   webhooks:
     - state: 'deployed'
       type: 'codefresh'

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -48,7 +48,7 @@ services:
             COMPONENT: app
             ENV: lifecycle
     requires:
-      - name: backend-svc-required
+      - name: backend-svc-required-renamed
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc
@@ -61,7 +61,7 @@ services:
           - master.pdb.create=true
           - master.pdb.minAvailable=50%
           - master.count=2
-  - name: backend-svc-required
+  - name: backend-svc-required-renamed
     helm:
       repository: vigneshrajsb/backend-svc
       branchName: main

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -47,8 +47,6 @@ services:
           env:
             COMPONENT: app
             ENV: lifecycle
-    requires:
-      - name: backend-svc-required-renamed
   - name: backend-cache
     helm:
       repository: vigneshrajsb/backend-svc
@@ -61,14 +59,3 @@ services:
           - master.pdb.create=true
           - master.pdb.minAvailable=50%
           - master.count=2
-  - name: backend-svc-required-renamed
-    helm:
-      repository: vigneshrajsb/backend-svc
-      branchName: main
-      chart:
-        name: redis
-        version: 20.3.0
-        repoUrl: https://charts.bitnami.com/bitnami
-        values:
-          - master.pdb.create=true
-          - master.pdb.minAvailable=50%

--- a/lifecycle.yaml
+++ b/lifecycle.yaml
@@ -1,65 +1,61 @@
----
-version: '1.0.0'
-
+version: 1.0.0
 environment:
   autoDeploy: true
   defaultServices:
-    - name: 'backend-cache'
-    - name: 'backend-svc'
-    - name: 'frontend'
-      repository: 'vigneshrajsb/lifecycle-examples'
-      branch: 'codex/lfc-remote-config-fixture'
-    - name: 'backend'
-      repository: 'vigneshrajsb/lifecycle-examples'
-      branch: 'codex/lfc-remote-config-fixture'
-    - name: 'remote-fixture-a'
-      repository: 'vigneshrajsb/lifecycle-examples'
-      branch: 'codex/lfc-remote-config-fixture'
+    - name: backend-cache
+    - name: backend-svc
+    - name: frontend
+      repository: vigneshrajsb/lifecycle-examples
+      branch: codex/lfc-remote-config-fixture
+    - name: backend
+      repository: vigneshrajsb/lifecycle-examples
+      branch: codex/lfc-remote-config-fixture
+    - name: remote-fixture-a
+      repository: vigneshrajsb/lifecycle-examples
+      branch: codex/lfc-remote-config-fixture
   optionalServices:
-    - name: 'cache'
-      repository: 'vigneshrajsb/lifecycle-examples'
-      branch: 'codex/lfc-remote-config-fixture'
+    - name: cache
+      repository: vigneshrajsb/lifecycle-examples
+      branch: codex/lfc-remote-config-fixture
   webhooks:
-    - state: 'deployed'
-      type: 'codefresh'
+    - state: deployed
+      type: codefresh
       name: 'lfc: deployed'
-      description: 'Lifecycle deployed webhook'
-      pipelineId: '6716ee061897917c1bf1ab5c'
-      trigger: 'deploy-lfc'
+      description: Lifecycle deployed webhook
+      pipelineId: 6716ee061897917c1bf1ab5c
+      trigger: deploy-lfc
       env:
-        branch: 'main'   
-        ENV: 'lifecycle'
-    
+        branch: main
+        ENV: lifecycle
 services:
-  - name: "backend-svc"
+  - name: backend-svc
     helm:
-      repository: "vigneshrajsb/backend-svc"
-      branchName: "main"
+      repository: vigneshrajsb/backend-svc
+      branchName: main
       grpc: true
       chart:
-        name: 'goodrx-app'
+        name: goodrx-app
         valueFiles:
-          - 'sysops/helm/common.yaml'
-          - 'sysops/helm/lfc/service/grpc-service.yaml'
+          - sysops/helm/common.yaml
+          - sysops/helm/lfc/service/grpc-service.yaml
       docker:
-        defaultTag: "main"
+        defaultTag: main
         app:
-          dockerfilePath: "backend-svc/Dockerfile"
+          dockerfilePath: backend-svc/Dockerfile
           ports:
             - 8080
           env:
-            COMPONENT: "app"
-            ENV: "lifecycle"
-
-  - name: "backend-cache"
+            COMPONENT: app
+            ENV: lifecycle
+  - name: backend-cache
     helm:
-      repository: "vigneshrajsb/backend-svc"
-      branchName: "main"
+      repository: vigneshrajsb/backend-svc
+      branchName: main
       chart:
-        name: "redis"
+        name: redis
         version: 20.3.0
-        repoUrl: "https://charts.bitnami.com/bitnami"
+        repoUrl: https://charts.bitnami.com/bitnami
         values:
-          - "master.pdb.create=true"
-          - "master.pdb.minAvailable=50%"
-          - "master.count=2"
+          - master.pdb.create=true
+          - master.pdb.minAvailable=50%
+          - master.count=2


### PR DESCRIPTION
Adds Lifecycle fixture services copied from lifecycle-examples under backend-specific names for remote repository reconciliation testing.